### PR TITLE
chore: use HTTPS for submodule over SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "openzl"]
 	path = openzl
-	url = git@github.com:facebook/openzl.git
+	url = https://github.com/facebook/openzl.git


### PR DESCRIPTION
HTTPS is generally more accessible, and you don't need an SSH key to clone.