### PR TITLE
fix: compile on windows-msvc with clang-cl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           - {os: ubuntu, toolchain: stable}
           - {os: ubuntu, toolchain: "1.71"}
-          # - {os: windows, toolchain: stable-msvc}
+          - {os: windows, toolchain: stable-msvc}
           - {os: windows, toolchain: stable-gnu}
           - {os: macos, toolchain: stable}
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
On Windows, `clang-cl` is required to compile, because MSVC hasn't managed to backport C++ 20 designated initializers to C11 yet.

I'm not sure if `clang-cl` is installed in CI by default. If not, I'll add a step for this.